### PR TITLE
[packaging] Remove python dependency. Cleanup spec. JB#50718

### DIFF
--- a/rpm/sp-smaps.spec
+++ b/rpm/sp-smaps.spec
@@ -2,11 +2,9 @@ Name:       sp-smaps
 Summary:    Utilities for collecting whole system SMAPS data
 Version:    0.4.2.2
 Release:    1
-Group:      Development/Tools
 License:    GPLv2
-URL:        https://github.com/mer-tools/sp-smaps
+URL:        https://github.com/sailfishos/sp-smaps
 Source0:    %{name}-%{version}.tar.gz
-BuildRequires:  python
 BuildRequires:  libsysperf-devel
 
 %description
@@ -14,27 +12,24 @@ Utilities for collecting whole system SMAPS data and post-processing the informa
 
 %package doc
 Summary:   Documentation for %{name}
-Group:     Documentation
+BuildArch: noarch
 Requires:  %{name} = %{version}-%{release}
 
 %description doc
 Man pages for %{name}.
 
 %prep
-%setup -q -n %{name}-%{version}
+%autosetup -n %{name}-%{version}
 
 %build
 # building is done in during install. Empty build section to avoid rpmlint warning
 
 %install
-rm -rf %{buildroot}
-make install DESTDIR=%{buildroot}
-
-mkdir -p %{buildroot}%{_docdir}/%{name}-%{version}
-install -m0644 README.txt %{buildroot}%{_docdir}/%{name}-%{version}
+%make_install
 
 %files
 %defattr(-,root,root,-)
+%license COPYING
 %{_bindir}/sp_smaps_analyze
 %{_bindir}/sp_smaps_appvals
 %{_bindir}/sp_smaps_diff
@@ -52,9 +47,8 @@ install -m0644 README.txt %{buildroot}%{_docdir}/%{name}-%{version}
 %{_datadir}/sp-smaps-visualize/jquery.min.js
 %{_datadir}/sp-smaps-visualize/jquery.tablesorter.js
 %{_datadir}/sp-smaps-visualize/tablesorter.css
-%license COPYING
 
 %files doc
 %defattr(-,root,root,-)
+%doc README.txt
 %{_mandir}/man1/sp_smaps*
-%{_docdir}/%{name}-%{version}

--- a/sp_smaps_filter.c
+++ b/sp_smaps_filter.c
@@ -55,6 +55,7 @@
 #include <assert.h>
 #include <math.h>
 #include <errno.h>
+#include <limits.h>
 
 #include <sys/types.h>
 #include <sys/stat.h>
@@ -3546,8 +3547,8 @@ out:
 static int
 copy_to_workdir(const char *workdir, const char *fn)
 {
-  char src[512];
-  char dst[512];
+  char src[PATH_MAX];
+  char dst[PATH_MAX];
   snprintf(src, sizeof(src), "/usr/share/sp-smaps-visualize/%s", fn);
   src[sizeof(src)-1] = 0;
   snprintf(dst, sizeof(dst), "%s/%s", workdir, fn);

--- a/sp_smaps_snapshot.c
+++ b/sp_smaps_snapshot.c
@@ -60,6 +60,7 @@
 #include <errno.h>
 #include <dirent.h>
 #include <sched.h>
+#include <limits.h>
 
 #define MSG_DISABLE_PROGRESS 0
 
@@ -695,7 +696,7 @@ static int snapshot_all(void)
     if( '1' <= de->d_name[0] && de->d_name[0] <= '9' )
     {
       char exe[256];
-      char path[256];
+      char path[PATH_MAX];
       proc_pid_status_t status;
       size_t smaps_bytes;
       char *name = NULL;


### PR DESCRIPTION
Fix some snprintf warnings.

Python3 will be still used by the libsysperf dependency which will pull in python3.